### PR TITLE
Changed laracasts/generators constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "~4.0",
         "phpspec/phpspec": "~2.1",
         "jrmadsen67/mahana-laravel5-generators": "dev-master",
-        "laracasts/generators": "dev"
+        "laracasts/generators": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`"laracasts/generators": "dev"` caused the following error on install:

> The requested package laracasts/generators dev exists as laracasts/generators[1.0, 1.0.1, 1.0.2, 1.0.3, 1.1, 1.1.1, 1.1.2, 1.1.3, dev-master] but these are rejected by your constraint.

`"laracasts/generators": "dev-master"` is the correct constraint I believe.
